### PR TITLE
[FEATURE] specify output field delimiter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-structopt = "0.3.0"
+structopt = "0.3"
 regex = "1"
 lazy_static = "1"

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ flamegraph_commit: release-debug
 
 .PHONY: test
 test:
+	cargo test
 	test/e2e_test.sh
 
 bench: release

--- a/src/choice.rs
+++ b/src/choice.rs
@@ -51,12 +51,16 @@ impl Choice {
                 }
             }
 
+            let mut iter = stack.iter().rev().peekable();
             loop {
-                match stack.pop() {
+                match iter.next() {
                     Some(s) => Choice::write_bytes(
                         handle,
                         s.as_bytes(),
-                        Some(config.opt.output_field_separator),
+                        match iter.peek() {
+                            Some(_) => Some(config.opt.output_field_separator),
+                            None => None,
+                        },
                     ),
                     None => break,
                 }

--- a/src/choice.rs
+++ b/src/choice.rs
@@ -140,11 +140,15 @@ impl Choice {
             }
         };
         if num_bytes_written > 0 && print_separator {
-            match handle.write(&config.output_separator) {
-                Ok(_) => (),
-                Err(e) => eprintln!("Failed to write to output: {}", e),
-            }
+            Choice::write_separator(config, handle);
         };
+    }
+
+    pub fn write_separator<W: Write>(config: &Config, handle: &mut BufWriter<W>) {
+        match handle.write(&config.output_separator) {
+            Ok(_) => (),
+            Err(e) => eprintln!("Failed to write to output: {}", e),
+        }
     }
 
     pub fn is_reverse_range(&self) -> bool {

--- a/src/choice.rs
+++ b/src/choice.rs
@@ -583,6 +583,28 @@ mod tests {
                 MockStdout::str_from_buf_writer(handle)
             );
         }
+
+        #[test]
+        fn print_3_to_1_with_output_field_separator() {
+            let config = Config::from_iter(vec!["choose", "3:1", "-o", "#"]);
+            let mut handle = BufWriter::new(MockStdout::new());
+            config.opt.choice[0].print_choice(&String::from("a b c d"), &config, &mut handle);
+            assert_eq!(
+                String::from("d#c#b"),
+                MockStdout::str_from_buf_writer(handle)
+            );
+        }
+
+        #[test]
+        fn print_0_to_neg_2_with_output_field_separator() {
+            let config = Config::from_iter(vec!["choose", "0:-2", "-o", "#"]);
+            let mut handle = BufWriter::new(MockStdout::new());
+            config.opt.choice[0].print_choice(&String::from("a b c d"), &config, &mut handle);
+            assert_eq!(
+                String::from("a#b#c"),
+                MockStdout::str_from_buf_writer(handle)
+            );
+        }
     }
 
     mod is_reverse_range_tests {

--- a/src/choice.rs
+++ b/src/choice.rs
@@ -575,11 +575,11 @@ mod tests {
 
         #[test]
         fn print_1_to_3_with_output_field_separator() {
-            let config = Config::from_iter(vec!["choose", "1:3", "-o", "#$%"]);
+            let config = Config::from_iter(vec!["choose", "1:3", "-o", "#"]);
             let mut handle = BufWriter::new(MockStdout::new());
             config.opt.choice[0].print_choice(&String::from("a b c d"), &config, &mut handle);
             assert_eq!(
-                String::from("b#$%c#$%d"),
+                String::from("b#c#d"),
                 MockStdout::str_from_buf_writer(handle)
             );
         }

--- a/src/choice.rs
+++ b/src/choice.rs
@@ -564,6 +564,17 @@ mod tests {
             config.opt.choice[0].print_choice(&String::from("a:b::c:::d"), &config, &mut handle);
             assert_eq!(String::from("d"), MockStdout::str_from_buf_writer(handle));
         }
+
+        #[test]
+        fn print_1_to_3_with_output_field_separator() {
+            let config = Config::from_iter(vec!["choose", "1:3", "-o", "#$%"]);
+            let mut handle = BufWriter::new(MockStdout::new());
+            config.opt.choice[0].print_choice(&String::from("a b c d"), &config, &mut handle);
+            assert_eq!(
+                String::from("b#$%c#$%d"),
+                MockStdout::str_from_buf_writer(handle)
+            );
+        }
     }
 
     mod is_reverse_range_tests {

--- a/src/choice.rs
+++ b/src/choice.rs
@@ -53,7 +53,9 @@ impl Choice {
 
             loop {
                 match stack.pop() {
-                    Some(s) => Choice::write_bytes(handle, s.as_bytes()),
+                    Some(s) => {
+                        Choice::write_bytes(handle, s.as_bytes(), config.opt.output_field_separator)
+                    }
                     None => break,
                 }
             }
@@ -78,11 +80,11 @@ impl Choice {
 
             if end > start {
                 for word in vec[start..=std::cmp::min(end, vec.len() - 1)].iter() {
-                    Choice::write_bytes(handle, word.as_bytes());
+                    Choice::write_bytes(handle, word.as_bytes(), config.opt.output_field_separator);
                 }
             } else if self.start < 0 {
                 for word in vec[end..=std::cmp::min(start, vec.len() - 1)].iter().rev() {
-                    Choice::write_bytes(handle, word.as_bytes());
+                    Choice::write_bytes(handle, word.as_bytes(), config.opt.output_field_separator);
                 }
             }
         } else {
@@ -92,7 +94,9 @@ impl Choice {
 
             for i in 0..=(self.end - self.start) {
                 match line_iter.next() {
-                    Some(s) => Choice::write_bytes(handle, s.as_bytes()),
+                    Some(s) => {
+                        Choice::write_bytes(handle, s.as_bytes(), config.opt.output_field_separator)
+                    }
                     None => break,
                 };
 
@@ -103,7 +107,11 @@ impl Choice {
         }
     }
 
-    fn write_bytes<WriterType: Write>(handle: &mut BufWriter<WriterType>, b: &[u8]) {
+    fn write_bytes<WriterType: Write>(
+        handle: &mut BufWriter<WriterType>,
+        b: &[u8],
+        output_field_separator: char,
+    ) {
         let num_bytes_written = match handle.write(b) {
             Ok(x) => x,
             Err(e) => {
@@ -112,7 +120,7 @@ impl Choice {
             }
         };
         if num_bytes_written > 0 {
-            match handle.write(b" ") {
+            match handle.write(&[output_field_separator as u8]) {
                 Ok(_) => (),
                 Err(e) => eprintln!("Failed to write to output: {}", e),
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@ lazy_static! {
 pub struct Config {
     pub opt: Opt,
     pub separator: Regex,
+    pub output_separator: Box<[u8]>,
 }
 
 impl Config {
@@ -50,7 +51,16 @@ impl Config {
             }
         };
 
-        Config { opt, separator }
+        let output_separator = match opt.output_field_separator.clone() {
+            Some(s) => s.into_boxed_str().into_boxed_bytes(),
+            None => Box::new([0x20; 1]),
+        };
+
+        Config {
+            opt,
+            separator,
+            output_separator,
+        }
     }
 
     pub fn parse_choice(src: &str) -> Result<Choice, ParseIntError> {
@@ -90,6 +100,10 @@ impl Config {
         };
 
         return Ok(Choice::new(start, end));
+    }
+
+    pub fn parse_output_field_separator(src: &str) -> String {
+        String::from(src)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,14 +39,11 @@ fn main() {
     while let Some(line) = reader.read_line(&mut buffer) {
         match line {
             Ok(l) => {
-                let mut choice_iter = &mut config.opt.choice.iter().peekable();
+                let choice_iter = &mut config.opt.choice.iter().peekable();
                 while let Some(choice) = choice_iter.next() {
                     choice.print_choice(&l, &config, &mut handle);
                     if choice_iter.peek().is_some() {
-                        match handle.write(&config.output_separator) {
-                            Ok(_) => (),
-                            Err(e) => eprintln!("Failed to write to output: {}", e),
-                        }
+                        choice::Choice::write_separator(&config, &mut handle);
                     }
                 }
                 match handle.write(b"\n") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,8 +39,15 @@ fn main() {
     while let Some(line) = reader.read_line(&mut buffer) {
         match line {
             Ok(l) => {
-                for choice in &config.opt.choice {
+                let mut choice_iter = &mut config.opt.choice.iter().peekable();
+                while let Some(choice) = choice_iter.next() {
                     choice.print_choice(&l, &config, &mut handle);
+                    if choice_iter.peek().is_some() {
+                        match handle.write(&config.output_separator) {
+                            Ok(_) => (),
+                            Err(e) => eprintln!("Failed to write to output: {}", e),
+                        }
+                    }
                 }
                 match handle.write(b"\n") {
                     Ok(_) => (),

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -13,8 +13,8 @@ pub struct Opt {
     pub field_separator: Option<String>,
 
     /// Specify output field separator
-    #[structopt(short, long, default_value = " ")]
-    pub output_field_separator: char,
+    #[structopt(short, long, parse(from_str = Config::parse_output_field_separator))]
+    pub output_field_separator: Option<String>,
 
     /// Use non-greedy field separators
     #[structopt(short, long)]

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -13,8 +13,8 @@ pub struct Opt {
     pub field_separator: Option<String>,
 
     /// Specify output field separator
-    #[structopt(short, long)]
-    pub output_field_separator: Option<String>,
+    #[structopt(short, long, default_value = " ")]
+    pub output_field_separator: char,
 
     /// Use non-greedy field separators
     #[structopt(short, long)]

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -12,6 +12,10 @@ pub struct Opt {
     #[structopt(short, long)]
     pub field_separator: Option<String>,
 
+    /// Specify output field separator
+    #[structopt(short, long)]
+    pub output_field_separator: Option<String>,
+
     /// Use non-greedy field separators
     #[structopt(short, long)]
     pub non_greedy: bool,

--- a/test/choose_1:3of%.txt
+++ b/test/choose_1:3of%.txt
@@ -1,0 +1,6 @@
+ipsum%dolor%sit
+ut%labore%et
+exercitation%ullamco%laboris
+aute%irure%dolor
+nulla%pariatur.%Excepteur
+qui%officia%deserunt

--- a/test/choose_1_3of%.txt
+++ b/test/choose_1_3of%.txt
@@ -1,0 +1,6 @@
+ipsum%sit
+ut%et
+exercitation%laboris
+aute%dolor
+nulla%Excepteur
+qui%deserunt

--- a/test/choose_1_3of.txt
+++ b/test/choose_1_3of.txt
@@ -1,0 +1,6 @@
+ipsumsit
+utet
+exercitationlaboris
+autedolor
+nullaExcepteur
+quideserunt

--- a/test/e2e_test.sh
+++ b/test/e2e_test.sh
@@ -14,6 +14,9 @@ diff -w <(cargo run -- 9 -i ${test_dir}/lorem.txt 2>/dev/null) <(cat "${test_dir
 diff -w <(cargo run -- 12 -i ${test_dir}/lorem.txt 2>/dev/null) <(cat "${test_dir}/choose_12.txt")
 diff -w <(cargo run -- 4:2 -i ${test_dir}/lorem.txt 2>/dev/null) <(cat "${test_dir}/choose_4:2.txt")
 diff -w <(cargo run -- -4:-2 -i ${test_dir}/lorem.txt 2>/dev/null) <(cat "${test_dir}/choose_-4:-2.txt")
+diff -w <(cargo run -- 1:3 -o % -i ${test_dir}/lorem.txt 2>/dev/null) <(cat "${test_dir}/choose_1:3of%.txt")
+diff -w <(cargo run -- 1 3 -o % -i ${test_dir}/lorem.txt 2>/dev/null) <(cat "${test_dir}/choose_1_3of%.txt")
+diff -w <(cargo run -- 1 3 -o '' -i ${test_dir}/lorem.txt 2>/dev/null) <(cat "${test_dir}/choose_1_3of.txt")
 # add tests for different delimiters
 # add tests using piping
 


### PR DESCRIPTION
Adds the `-o` flag to specify an output field delimiter. Can be empty or an arbitrary length `String`. Default value is one space `" "`.

This feature does incur some (~12%) performance penalty. Hopefully this can be addressed before next release.