### PR TITLE
Add character-wise `choose`ing

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -51,9 +51,15 @@ impl Config {
             }
         };
 
-        let output_separator = match opt.output_field_separator.clone() {
-            Some(s) => s.into_boxed_str().into_boxed_bytes(),
-            None => Box::new([0x20; 1]),
+        let output_separator = match opt.character_wise {
+            false => match opt.output_field_separator.clone() {
+                Some(s) => s.into_boxed_str().into_boxed_bytes(),
+                None => Box::new([0x20; 1]),
+            },
+            true => match opt.output_field_separator.clone() {
+                Some(s) => s.into_boxed_str().into_boxed_bytes(),
+                None => Box::new([]),
+            },
         };
 
         Config {

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,8 +10,11 @@ mod choice;
 mod config;
 mod opt;
 mod reader;
+mod writeable;
+mod writer;
 use config::Config;
 use opt::Opt;
+use writer::WriteReceiver;
 
 fn main() {
     let opt = Opt::from_args();
@@ -43,7 +46,7 @@ fn main() {
                 while let Some(choice) = choice_iter.next() {
                     choice.print_choice(&l, &config, &mut handle);
                     if choice_iter.peek().is_some() {
-                        choice::Choice::write_separator(&config, &mut handle);
+                        handle.write_separator(&config);
                     }
                 }
                 match handle.write(b"\n") {

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -8,29 +8,33 @@ use crate::config::Config;
 #[structopt(name = "choose", about = "`choose` sections from each line of files")]
 #[structopt(setting = structopt::clap::AppSettings::AllowLeadingHyphen)]
 pub struct Opt {
-    /// Specify field separator other than whitespace, using Rust `regex` syntax
+    /// Choose fields by character number
     #[structopt(short, long)]
-    pub field_separator: Option<String>,
-
-    /// Specify output field separator
-    #[structopt(short, long, parse(from_str = Config::parse_output_field_separator))]
-    pub output_field_separator: Option<String>,
-
-    /// Use non-greedy field separators
-    #[structopt(short, long)]
-    pub non_greedy: bool,
-
-    /// Use exclusive ranges, similar to array indexing in many programming languages
-    #[structopt(short = "x", long)]
-    pub exclusive: bool,
+    pub character_wise: bool,
 
     /// Activate debug mode
     #[structopt(short, long)]
     pub debug: bool,
 
+    /// Use exclusive ranges, similar to array indexing in many programming languages
+    #[structopt(short = "x", long)]
+    pub exclusive: bool,
+
+    /// Specify field separator other than whitespace, using Rust `regex` syntax
+    #[structopt(short, long)]
+    pub field_separator: Option<String>,
+
     /// Input file
     #[structopt(short, long, parse(from_os_str))]
     pub input: Option<PathBuf>,
+
+    /// Use non-greedy field separators
+    #[structopt(short, long)]
+    pub non_greedy: bool,
+
+    /// Specify output field separator
+    #[structopt(short, long, parse(from_str = Config::parse_output_field_separator))]
+    pub output_field_separator: Option<String>,
 
     /// Fields to print. Either x, x:, :y, or x:y, where x and y are integers, colons indicate a
     /// range, and an empty field on either side of the colon continues to the beginning or end of

--- a/src/writeable.rs
+++ b/src/writeable.rs
@@ -1,0 +1,20 @@
+pub trait Writeable {
+    fn to_byte_buf(&self) -> Box<[u8]>;
+}
+
+impl Writeable for &str {
+    fn to_byte_buf(&self) -> Box<[u8]> {
+        return Box::from(self.as_bytes());
+    }
+}
+
+impl Writeable for char {
+    fn to_byte_buf(&self) -> Box<[u8]> {
+        let mut buf = [0; 4];
+        return self
+            .encode_utf8(&mut buf)
+            .to_owned()
+            .into_boxed_str()
+            .into_boxed_bytes();
+    }
+}

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,0 +1,31 @@
+use std::io::{BufWriter, Write};
+
+use crate::config::Config;
+use crate::writeable::Writeable;
+
+pub trait WriteReceiver {
+    fn write_choice<Wa: Writeable>(&mut self, b: Wa, config: &Config, print_separator: bool);
+    fn write_separator(&mut self, config: &Config);
+}
+
+impl<W: Write> WriteReceiver for BufWriter<W> {
+    fn write_choice<Wa: Writeable>(&mut self, b: Wa, config: &Config, print_separator: bool) {
+        let num_bytes_written = match self.write(&b.to_byte_buf()) {
+            Ok(x) => x,
+            Err(e) => {
+                eprintln!("Failed to write to output: {}", e);
+                0
+            }
+        };
+        if num_bytes_written > 0 && print_separator {
+            self.write_separator(config);
+        };
+    }
+
+    fn write_separator(&mut self, config: &Config) {
+        match self.write(&config.output_separator) {
+            Ok(_) => (),
+            Err(e) => eprintln!("Failed to write to output: {}", e),
+        }
+    }
+}

--- a/test/choose_0_3_c.txt
+++ b/test/choose_0_3_c.txt
@@ -1,0 +1,6 @@
+em i
+idid
+trud
+s au
+iat 
+pa q

--- a/test/e2e_test.sh
+++ b/test/e2e_test.sh
@@ -17,6 +17,7 @@ diff -w <(cargo run -- -4:-2 -i ${test_dir}/lorem.txt 2>/dev/null) <(cat "${test
 diff -w <(cargo run -- 1:3 -o % -i ${test_dir}/lorem.txt 2>/dev/null) <(cat "${test_dir}/choose_1:3of%.txt")
 diff -w <(cargo run -- 1 3 -o % -i ${test_dir}/lorem.txt 2>/dev/null) <(cat "${test_dir}/choose_1_3of%.txt")
 diff -w <(cargo run -- 1 3 -o '' -i ${test_dir}/lorem.txt 2>/dev/null) <(cat "${test_dir}/choose_1_3of.txt")
+diff -w <(cargo run -- 3:6 -c -i ${test_dir}/lorem.txt 2>/dev/null) <(cat "${test_dir}/choose_0_3_c.txt")
 # add tests for different delimiters
 # add tests using piping
 


### PR DESCRIPTION
Alphabetize structopt options

Add character-wise tests

Add character-wise switch

Add print-after-end test

Add empty default separator for char-wise mode

Add char-wise forward and negative printing

Add pure reverse printing

Change to char_wise to user `char` instead of `u8`

Adds support for unicode (read: emojis)

Adds a newline char to end of each char-wise test because that's how it
is

Add writing traits for better code structure

Merge repetitive codepaths with generics

Unify print_choice_* funtion names

Reorder functions in choice module

Rename variable to avoid name confusion

Make default case for loop more readable

Abstract default case print loop

Add e2e test

Move vec create to print_choice_negative