### PR TITLE
[bugfix] Add check for brokenpipe

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -69,7 +69,12 @@ fn main_generic<W: WriteReceiver>(opt: Opt, handle: &mut W) {
 
                 match handle.write(b"\n") {
                     Ok(_) => (),
-                    Err(e) => eprintln!("Failed to write to output: {}", e),
+                    Err(e) => {
+                        eprintln!("Failed to write to output: {}", e);
+                        if e.kind() == io::ErrorKind::BrokenPipe {
+                            process::exit(0)
+                        }
+                    }
                 }
             }
             Err(e) => println!("Failed to read line: {}", e),


### PR DESCRIPTION
Partially fixes https://github.com/theryangeary/choose/issues/36

There are a few other places in the write trait where errors are being printed an not propagated. I'd also argue that any write error that bubbles all the way back to main should be exited on instead of just printed. 