### PR TITLE
README: add MacPorts install info

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -142,6 +142,12 @@ Homebrew:
 $ brew install choose-rust
 ```
 
+MacPorts:
+
+```
+$ sudo port install choose
+```
+
 ### Benchmarking
 
 Benchmarking is performed using the [`bench` utility](https://github.com/Gabriel439/bench).


### PR DESCRIPTION
`choose` is available via MacPorts: https://ports.macports.org/port/choose/