### PR TITLE
[WIP] Switch from structopt to clap v4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,12 +23,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
 name = "backslash"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -36,9 +30,15 @@ checksum = "35a89ea09f2c7f3c81711c0db7d389d86a9d66fa15a7067e6fd6dbef863ef786"
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "cc"
+version = "1.0.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
 name = "choose"
@@ -52,26 +52,25 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.22"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
+checksum = "31c9484ccdc4cb8e7b117cbd0eb150c7c0f04464854e4679aeb50ef03b32d003"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
- "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
- "textwrap",
+ "terminal_size",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.18"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "ca689d7434ce44517a12a89456b2be4d1ea1cafcd8f581978c03d45f5a5c12a7"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -82,18 +81,33 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.12.3"
+name = "errno"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "heck"
@@ -103,22 +117,18 @@ checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.14"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9586eedd4ce6b3c498bc3b4dd92fc9f11166aa908a914071953768066c67909"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
 
 [[package]]
-name = "indexmap"
-version = "1.9.1"
+name = "io-lifetimes"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
-dependencies = [
- "autocfg",
- "hashbrown",
-]
+checksum = "1ea37f355c05dde75b84bba2d767906ad522e97cd9e2eef2be7a4ab7fb442c06"
 
 [[package]]
 name = "lazy_static"
@@ -128,9 +138,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.71"
+version = "0.2.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
+checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "memchr"
@@ -152,9 +168,9 @@ checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
 name = "proc-macro-error"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc175e9777c3116627248584e8f8b3e2987405cabe1c0adf7d1dd28f09dc7880"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
@@ -165,22 +181,20 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error-attr"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cc9795ca17eb581285ec44936da7fc2335a3f34f2ddd13118b6f4d515435c50"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
- "syn-mid",
  "version_check",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bd7356a8122b6c4a24a82b278680c73357984ca2fc79a0f9fa6dea7dced7c58"
+checksum = "3edcd08cf4fea98d1ae6c9ddd3b8ccb1acac7c3693d62625969a7daa04a2ae36"
 dependencies = [
  "unicode-ident",
 ]
@@ -213,6 +227,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
 
 [[package]]
+name = "rustix"
+version = "0.35.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbb2fda4666def1433b1b05431ab402e42a1084285477222b72d6c564c417cef"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,24 +248,13 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.100"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52205623b1b0f064a4e71182c3b18ae902267282930c6d5462c91b859668426e"
+checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "syn-mid"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -250,10 +267,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.15.1"
+name = "terminal_size"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
+checksum = "8440c860cf79def6164e4a0a983bcc2305d82419177a0e0c71930d049e3ac5a1"
+dependencies = [
+ "rustix",
+ "windows-sys",
+]
 
 [[package]]
 name = "thread_local"
@@ -272,9 +293,9 @@ checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
 
 [[package]]
 name = "version_check"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "winapi"
@@ -306,3 +327,46 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,15 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,6 +21,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backslash"
@@ -48,34 +45,61 @@ name = "choose"
 version = "1.3.4"
 dependencies = [
  "backslash",
+ "clap",
  "lazy_static",
  "regex",
- "structopt",
 ]
 
 [[package]]
 name = "clap"
-version = "2.33.1"
+version = "3.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129"
+checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "once_cell",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
 ]
 
 [[package]]
-name = "heck"
-version = "0.3.1"
+name = "clap_derive"
+version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
- "unicode-segmentation",
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -84,6 +108,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9586eedd4ce6b3c498bc3b4dd92fc9f11166aa908a914071953768066c67909"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+dependencies = [
+ "autocfg",
+ "hashbrown",
 ]
 
 [[package]]
@@ -103,6 +137,18 @@ name = "memchr"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+
+[[package]]
+name = "once_cell"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
 name = "proc-macro-error"
@@ -132,18 +178,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.18"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa"
+checksum = "7bd7356a8122b6c4a24a82b278680c73357984ca2fc79a0f9fa6dea7dced7c58"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.7"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
@@ -168,43 +214,19 @@ checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de2f5e239ee807089b62adce73e48c625e0ed80df02c7ab3f068f5db5281065c"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "510413f9de616762a4fbeab62509bf15c729603b72d7cd71280fbca431b1c118"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.33"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d5d96e8cbb005d6959f119f773bfaebb5684296108fb32600c00cde305b2cd"
+checksum = "52205623b1b0f064a4e71182c3b18ae902267282930c6d5462c91b859668426e"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -219,13 +241,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.11.0"
+name = "termcolor"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
- "unicode-width",
+ "winapi-util",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "thread_local"
@@ -237,28 +265,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.6.0"
+name = "unicode-ident"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
 
 [[package]]
 name = "version_check"
@@ -281,6 +291,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-structopt = "0.3"
-regex = "1"
-lazy_static = "1"
 backslash = "0"
+clap = { version = "3.2.22", features = ["derive"] }
+lazy_static = "1"
+regex = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,6 @@ exclude = [
 
 [dependencies]
 backslash = "0"
-clap = { version = "3.2.22", features = ["derive"] }
+clap = { version = "4.0.2", features = ["derive", "wrap_help"] }
 lazy_static = "1"
 regex = "1"

--- a/readme.md
+++ b/readme.md
@@ -44,48 +44,37 @@ Please see our guidelines in [contributing.md](contributing.md).
 
 ```
 $ choose --help
-choose 1.3.4
 `choose` sections from each line of files
 
-USAGE:
-    choose [OPTIONS] <CHOICES>...
+Usage: choose [OPTIONS] <CHOICES>...
 
-ARGS:
-    <CHOICES>...    Fields to print. Either a, a:b, a..b, or a..=b, where a and b are integers.
-                    The beginning or end of a range can be omitted, resulting in including the
-                    beginning or end of the line, respectively. a:b is inclusive of b (unless
-                    overridden by -x). a..b is exclusive of b and a..=b is inclusive of b
+Arguments:
+  <CHOICES>...  Fields to print. Either a, a:b, a..b, or a..=b, where a and b are integers.
+                The beginning or end of a range can be omitted, resulting in including the
+                beginning or end of the line, respectively. a:b is inclusive of b (unless
+                overridden by -x). a..b is exclusive of b and a..=b is inclusive of b
 
-OPTIONS:
-    -c, --character-wise
-            Choose fields by character number
-
-    -d, --debug
-            Activate debug mode
-
-    -f, --field-separator <FIELD_SEPARATOR>
-            Specify field separator other than whitespace, using Rust `regex` syntax
-
-    -h, --help
-            Print help information
-
-    -i, --input <INPUT>
-            Input file
-
-    -n, --non-greedy
-            Use non-greedy field separators
-
-    -o, --output-field-separator <OUTPUT_FIELD_SEPARATOR>
-            Specify output field separator
-
-        --one-indexed
-            Index from 1 instead of 0
-
-    -V, --version
-            Print version information
-
-    -x, --exclusive
-            Use exclusive ranges, similar to array indexing in many programming languages
+Options:
+  -c, --character-wise
+          Choose fields by character number
+  -d, --debug
+          Activate debug mode
+  -x, --exclusive
+          Use exclusive ranges, similar to array indexing in many programming languages
+  -f, --field-separator <FIELD_SEPARATOR>
+          Specify field separator other than whitespace, using Rust `regex` syntax
+  -i, --input <INPUT>
+          Input file
+  -n, --non-greedy
+          Use non-greedy field separators
+      --one-indexed
+          Index from 1 instead of 0
+  -o, --output-field-separator <OUTPUT_FIELD_SEPARATOR>
+          Specify output field separator
+  -h, --help
+          Print help information
+  -V, --version
+          Print version information
 ```
 
 ### Examples

--- a/readme.md
+++ b/readme.md
@@ -44,32 +44,48 @@ Please see our guidelines in [contributing.md](contributing.md).
 
 ```
 $ choose --help
-choose 1.2.0
+choose 1.3.4
 `choose` sections from each line of files
 
 USAGE:
-    choose [FLAGS] [OPTIONS] <choices>...
-
-FLAGS:
-    -c, --character-wise    Choose fields by character number
-    -d, --debug             Activate debug mode
-    -x, --exclusive         Use exclusive ranges, similar to array indexing in many programming languages
-    -h, --help              Prints help information
-    -n, --non-greedy        Use non-greedy field separators
-    -V, --version           Prints version information
-
-OPTIONS:
-    -f, --field-separator <field-separator>
-            Specify field separator other than whitespace, using Rust `regex` syntax
-
-    -i, --input <input>                                      Input file
-    -o, --output-field-separator <output-field-separator>    Specify output field separator
+    choose [OPTIONS] <CHOICES>...
 
 ARGS:
-    <choices>...    Fields to print. Either a, a:b, a..b, or a..=b, where a and b are integers. The beginning or end
-                    of a range can be omitted, resulting in including the beginning or end of the line,
-                    respectively. a:b is inclusive of b (unless overridden by -x). a..b is exclusive of b and a..=b
-                    is inclusive of b
+    <CHOICES>...    Fields to print. Either a, a:b, a..b, or a..=b, where a and b are integers.
+                    The beginning or end of a range can be omitted, resulting in including the
+                    beginning or end of the line, respectively. a:b is inclusive of b (unless
+                    overridden by -x). a..b is exclusive of b and a..=b is inclusive of b
+
+OPTIONS:
+    -c, --character-wise
+            Choose fields by character number
+
+    -d, --debug
+            Activate debug mode
+
+    -f, --field-separator <FIELD_SEPARATOR>
+            Specify field separator other than whitespace, using Rust `regex` syntax
+
+    -h, --help
+            Print help information
+
+    -i, --input <INPUT>
+            Input file
+
+    -n, --non-greedy
+            Use non-greedy field separators
+
+    -o, --output-field-separator <OUTPUT_FIELD_SEPARATOR>
+            Specify output field separator
+
+        --one-indexed
+            Index from 1 instead of 0
+
+    -V, --version
+            Print version information
+
+    -x, --exclusive
+            Use exclusive ranges, similar to array indexing in many programming languages
 ```
 
 ### Examples

--- a/src/choice/mod.rs
+++ b/src/choice/mod.rs
@@ -18,7 +18,7 @@ pub struct Choice {
     reversed: bool,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ChoiceKind {
     Single,
     RustExclusiveRange,
@@ -190,7 +190,7 @@ impl Choice {
     ///
     /// Returns Ok(None) if the resulting choice range would not include any item in the slice.
     fn get_negative_start_end<T>(&self, slice: &[T]) -> Result<Option<(usize, usize)>> {
-        if slice.len() == 0 {
+        if slice.is_empty() {
             return Ok(None);
         }
 
@@ -222,10 +222,7 @@ impl Choice {
                 // then we assume self.end is negative
                 let start = self.start.try_into()?;
 
-                if end_abs <= slice_len_as_isize
-                    || start <= slice.len()
-                    || (end_abs > slice_len_as_isize && start > slice.len())
-                {
+                if end_abs <= slice_len_as_isize || start <= slice.len() || start > slice.len() {
                     let end = slice.len().saturating_sub(end_abs.try_into()?);
                     Ok(Some((
                         std::cmp::min(start, slice.len().saturating_sub(1)),
@@ -238,10 +235,7 @@ impl Choice {
                 // then we assume self.start is negative
                 let end = self.end.try_into()?;
 
-                if start_abs <= slice_len_as_isize
-                    || end <= slice.len()
-                    || (start_abs > slice_len_as_isize && end > slice.len())
-                {
+                if start_abs <= slice_len_as_isize || end <= slice.len() || end > slice.len() {
                     let start = slice.len().saturating_sub(start_abs.try_into()?);
                     Ok(Some((
                         std::cmp::min(start, slice.len().saturating_sub(1)),

--- a/src/choice/mod.rs
+++ b/src/choice/mod.rs
@@ -9,7 +9,7 @@ use crate::writer::WriteReceiver;
 #[cfg(test)]
 mod test;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Choice {
     pub start: isize,
     pub end: isize,
@@ -18,7 +18,7 @@ pub struct Choice {
     reversed: bool,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ChoiceKind {
     Single,
     RustExclusiveRange,

--- a/src/choice/test/mod.rs
+++ b/src/choice/test/mod.rs
@@ -14,7 +14,7 @@ impl Config {
         I: IntoIterator,
         I::Item: Into<OsString> + Clone,
     {
-        Config::new(Opt::from_iter(iter))
+        Config::new(Opt::parse_from(iter))
     }
 }
 

--- a/src/choice/test/mod.rs
+++ b/src/choice/test/mod.rs
@@ -1,8 +1,8 @@
 use crate::config::Config;
 use crate::opt::Opt;
+use clap::Parser;
 use std::ffi::OsString;
 use std::io::{self, BufWriter, Write};
-use structopt::StructOpt;
 
 mod get_negative_start_end;
 mod is_reverse_range;

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,7 @@ fn main() {
                         eprintln!("Failed to write to output: {}", e)
                     }
                 }
-                e @ _ => eprintln!("Error: {}", e),
+                e => eprintln!("Error: {}", e),
             }
         }
     }
@@ -85,11 +85,11 @@ fn main_generic<W: WriteReceiver>(opt: Opt, handle: &mut W) -> Result<()> {
         match line {
             Ok(l) => {
                 let l = if (config.opt.character_wise || config.opt.field_separator.is_some())
-                    && l.ends_with("\n")
+                    && l.ends_with('\n')
                 {
                     &l[0..l.len().saturating_sub(1)]
                 } else {
-                    &l
+                    l
                 };
 
                 let choice_iter = &mut config.opt.choices.iter().peekable();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
+use clap::Parser;
 use std::fs::File;
 use std::io::{self, Read};
 use std::process;
-use structopt::StructOpt;
 
 #[macro_use]
 extern crate lazy_static;
@@ -25,7 +25,18 @@ use result::Result;
 use writer::WriteReceiver;
 
 fn main() {
-    let opt = Opt::from_args();
+    // clap v3 exits with status code 2 on parse errors. For compatibility, we use exit code 1.
+    let opt = match Opt::try_parse() {
+        Ok(opt) => opt,
+        Err(e) if e.use_stderr() => {
+            let _ = e.print();
+            process::exit(1);
+        }
+        Err(e) => {
+            let _ = e.print();
+            process::exit(0);
+        }
+    };
 
     let stdout = io::stdout();
     let lock = stdout.lock();

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -1,49 +1,52 @@
 use std::path::PathBuf;
-use structopt::StructOpt;
 
 use crate::choice::Choice;
 use crate::parse;
 
-#[derive(Debug, StructOpt)]
-#[structopt(name = "choose", about = "`choose` sections from each line of files")]
-#[structopt(setting = structopt::clap::AppSettings::AllowLeadingHyphen)]
+#[derive(Debug, clap::Parser)]
+#[clap(
+    name = "choose",
+    version,
+    about = "`choose` sections from each line of files"
+)]
+#[clap(setting = clap::AppSettings::AllowLeadingHyphen)]
 pub struct Opt {
     /// Choose fields by character number
-    #[structopt(short, long)]
+    #[clap(short, long)]
     pub character_wise: bool,
 
     /// Activate debug mode
-    #[structopt(short, long)]
+    #[clap(short, long)]
     pub debug: bool,
 
     /// Use exclusive ranges, similar to array indexing in many programming languages
-    #[structopt(short = "x", long)]
+    #[clap(short = 'x', long)]
     pub exclusive: bool,
 
     /// Specify field separator other than whitespace, using Rust `regex` syntax
-    #[structopt(short, long)]
+    #[clap(short, long)]
     pub field_separator: Option<String>,
 
     /// Input file
-    #[structopt(short, long, parse(from_os_str))]
+    #[clap(short, long, parse(from_os_str))]
     pub input: Option<PathBuf>,
 
     /// Use non-greedy field separators
-    #[structopt(short, long)]
+    #[clap(short, long)]
     pub non_greedy: bool,
 
     /// Index from 1 instead of 0
-    #[structopt(long)]
+    #[clap(long)]
     pub one_indexed: bool,
 
     /// Specify output field separator
-    #[structopt(short, long, parse(from_str = parse::output_field_separator))]
+    #[clap(short, long, parse(from_str = parse::output_field_separator))]
     pub output_field_separator: Option<String>,
 
     /// Fields to print. Either a, a:b, a..b, or a..=b, where a and b are integers. The beginning
     /// or end of a range can be omitted, resulting in including the beginning or end of the line,
     /// respectively. a:b is inclusive of b (unless overridden by -x). a..b is
     /// exclusive of b and a..=b is inclusive of b.
-    #[structopt(required = true, min_values = 1, parse(try_from_str = parse::choice))]
+    #[clap(required = true, min_values = 1, parse(try_from_str = parse::choice))]
     pub choices: Vec<Choice>,
 }

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -3,50 +3,45 @@ use std::path::PathBuf;
 use crate::choice::Choice;
 use crate::parse;
 
-#[derive(Debug, clap::Parser)]
-#[clap(
-    name = "choose",
-    version,
-    about = "`choose` sections from each line of files"
-)]
-#[clap(setting = clap::AppSettings::AllowLeadingHyphen)]
+#[derive(clap::Parser)]
+#[command(version, about = "`choose` sections from each line of files")]
 pub struct Opt {
     /// Choose fields by character number
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub character_wise: bool,
 
     /// Activate debug mode
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub debug: bool,
 
     /// Use exclusive ranges, similar to array indexing in many programming languages
-    #[clap(short = 'x', long)]
+    #[arg(short = 'x', long)]
     pub exclusive: bool,
 
     /// Specify field separator other than whitespace, using Rust `regex` syntax
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub field_separator: Option<String>,
 
     /// Input file
-    #[clap(short, long, parse(from_os_str))]
+    #[arg(short, long)]
     pub input: Option<PathBuf>,
 
     /// Use non-greedy field separators
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub non_greedy: bool,
 
     /// Index from 1 instead of 0
-    #[clap(long)]
+    #[arg(long)]
     pub one_indexed: bool,
 
     /// Specify output field separator
-    #[clap(short, long, parse(from_str = parse::output_field_separator))]
+    #[arg(short, long, value_parser = parse::output_field_separator)]
     pub output_field_separator: Option<String>,
 
     /// Fields to print. Either a, a:b, a..b, or a..=b, where a and b are integers. The beginning
     /// or end of a range can be omitted, resulting in including the beginning or end of the line,
     /// respectively. a:b is inclusive of b (unless overridden by -x). a..b is
     /// exclusive of b and a..=b is inclusive of b.
-    #[clap(required = true, min_values = 1, parse(try_from_str = parse::choice))]
+    #[arg(allow_hyphen_values = true, value_parser = parse::choice)]
     pub choices: Vec<Choice>,
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -61,8 +61,8 @@ pub fn choice(src: &str) -> Result<Choice, ParseError> {
     Ok(Choice::new(start, end, kind))
 }
 
-pub fn output_field_separator(src: &str) -> String {
-    escape_ascii(src).unwrap()
+pub fn output_field_separator(src: &str) -> Result<String, std::string::FromUtf8Error> {
+    escape_ascii(src)
 }
 
 #[cfg(test)]

--- a/src/parse_error.rs
+++ b/src/parse_error.rs
@@ -9,8 +9,8 @@ pub enum ParseError {
 impl fmt::Display for ParseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            ParseError::ParseIntError(e) => write!(f, "{}", e.to_string()),
-            ParseError::ParseRangeError(e) => write!(f, "{}", e.to_string()),
+            ParseError::ParseIntError(e) => write!(f, "{}", e),
+            ParseError::ParseRangeError(e) => write!(f, "{}", e),
         }
     }
 }

--- a/src/parse_error.rs
+++ b/src/parse_error.rs
@@ -1,14 +1,18 @@
+use std::{error::Error, fmt};
+
 #[derive(Debug)]
 pub enum ParseError {
     ParseIntError(std::num::ParseIntError),
     ParseRangeError(crate::error::ParseRangeError),
 }
 
-impl ToString for ParseError {
-    fn to_string(&self) -> String {
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            ParseError::ParseIntError(e) => e.to_string(),
-            ParseError::ParseRangeError(e) => e.to_string(),
+            ParseError::ParseIntError(e) => write!(f, "{}", e.to_string()),
+            ParseError::ParseRangeError(e) => write!(f, "{}", e.to_string()),
         }
     }
 }
+
+impl Error for ParseError {}


### PR DESCRIPTION
As clap v3 is now out, and the structopt features are integrated into
(almost as-is), structopt is now in maintenance mode: no new feature
will be added [[1]]. Consequently, it seems appropriate to switch to
clap v3 to benefit from the continued development.

clap v3 is slightly larger than structopt. This is the affect on some
basic metrics:

    | Metric                | Before | After |
    |-----------------------|--------|-------|
    | compile release (sec) | 6.25   | 8.00  |
    | binary size (MB)      | 6.2    | 6.3   |

Also note that we break away from the default clap v3 behavior in one
case: exit codes. In the transition for v2 to v3, clap switched from an
exit status of 1 to an exit status of 2. For compatibility with previous
version of `choose`, we still return an exit code of 1, rather than 2.

[1]: https://docs.rs/structopt/latest/structopt/#maintenance

Tested: 
Ran `cargo test`:
        
    test result: ok. 206 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s

Ran `test/e2e_test.sh`:

    All tests passed

---

In addition, this PR cleans up some clippy lints while we're at it :). You can see these yourself if you checkout after the first commit and run `cargo clippy` with clippy v0.1.64.

I'd suggest reviewing patch-by-patch, I tried to organize the changes.